### PR TITLE
Add files via upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,23 @@
 React Native bridge for Adobe Analytics.
 
 ## Installation
+### Using npm
 ```
 $ npm install react-native-adobe-analytics --save
+$ react-native link react-native-adobe-analytics
 ```
-### Automatic linking
+### Using CocoaPods (iOS only)
+Add this to your Podfile and run `pod install`
 ```
-$ react-native link
+$ pod 'RNAdobeAnalytics', :path => '../node_modules/react-native-adobe-analytics'
 ```
+
+Consult the React Native documentation on how to [install React Native using CocoaPods.](https://facebook.github.io/react-native/docs/embedded-app-ios.html#install-react-native-using-cocoapods)
 
 ### Configuration file
 Get your ADBMobileConfig.json file from Adobe Mobile Services.
-- On iOS, add the ADBMobileConfig.json file to your XCode project so that it's accessible in your bundle.
-- On Android, the ADBMobileConfig.json file must be placed in the assets folder.
+- On iOS, add the `ADBMobileConfig.json` file to your XCode project so that it's accessible in your bundle.
+- On Android, the `ADBMobileConfig.json` file must be placed in the `assets` folder.
 
 ### Android Configuration
 #### Update `MainApplication.java`

--- a/RNAdobeAnalytics.podspec
+++ b/RNAdobeAnalytics.podspec
@@ -1,0 +1,17 @@
+require 'json'
+package_json = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+
+  s.name           = "RNAdobeAnalytics"
+  s.version        = package_json["version"]
+  s.summary        = package_json["description"]
+  s.homepage       = package_json["homepage"]
+  s.license        = package_json["license"]
+  s.author         = { package_json["author"] => package_json["author"] }
+  s.platform       = :ios, "7.0"
+  s.source         = { :git => "#{package_json["repository"]["url"]}.git", :tag => "v#{s.version}" }
+  s.source_files   = 'ios/*.{h,m}'
+  s.dependency 'React'
+
+end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-adobe-analytics",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "React Native bridge for Adobe Analytics",
   "author": "Small Town Heroes & VRT",
   "license": "MIT",
@@ -15,6 +15,10 @@
     "eslint": "eslint **/*.js",
     "format": "prettier --write --single-quote --bracket-spacing=true --print-width=120 '**/*.js'",
     "precommit": "lint-staged"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/smalltownheroes/react-native-adobe-analytics.git"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Add podspec file to allow installation of package via CocoaPods on iOS, as this seems to be a breaking change from React Native 0.61.x onwards.